### PR TITLE
Fix meta.yml. Test 8.10 and dev in CI.

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version: ['latest']
+        coq_version:
+          - '8.10'
+          - '8.11'
+          - 'dev'
         ocaml_version: ['minimal']
       fail-fast: false
     steps:

--- a/meta.yml
+++ b/meta.yml
@@ -37,6 +37,8 @@ maintainers:
 - name: Kartik Singhal
   nickname: k4rtik
 
+opam-file-maintainer: kartiksinghal@gmail.com
+
 license:
   fullname: MIT License
   identifier: MIT
@@ -44,7 +46,7 @@ license:
 supported_coq_versions:
   text: 8.10 or later
 
-tested_opam_coq_versions:
+tested_coq_opam_versions:
 - version: '8.10'
 - version: '8.11'
 - version: 'dev'


### PR DESCRIPTION
Sorry for the not working CI file of my previous PR. It was my mistake (because I misnamed one of the fields in `meta.yml`) that the generated file didn't make sense.

This PR fixes this and adds testing for 8.10 and Coq dev so that you have a better idea of what versions are supported at any time (it is best practice keeping the CI and what the README claims regarding supported versions in sync).