### PR TITLE
Added support for more recent versions of OCaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ clean: Makefile.coq
 	+make -f Makefile.coq clean
 
 Makefile.coq:
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQBIN)rocq makefile -f _CoqProject -o Makefile.coq
 
 %: Makefile.coq
 	+make -f Makefile.coq $@

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,7 +1,7 @@
 post-all:: little.native proof_sqrt.v test_vcg.lil
 
 little.native: extract_interpret.vo parse_little.mly llex.mll str_little.ml little.ml
-	$(CAMLBIN)ocamlbuild -no-hygiene -classic-display -libs nums $@
+	$(CAMLBIN)ocamlbuild -use-ocamlfind -package zarith $@
 
 proof_sqrt.v: context_sqrt.v tail_sqrt.v sqrt.lil little.native
 	./little.native -vcg-coq < sqrt.lil | cat context_sqrt.v - tail_sqrt.v > proof_sqrt.v

--- a/coq-semantics.opam
+++ b/coq-semantics.opam
@@ -31,7 +31,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "9.0"}
-  "num" 
+  "zarith"
   "ocamlbuild" {build}
 ]
 

--- a/little.ml
+++ b/little.ml
@@ -1,4 +1,4 @@
-open Big_int
+open Big_int_Z
 open Parse_little
 open Interp
 open Str_little

--- a/llex.mll
+++ b/llex.mll
@@ -13,7 +13,7 @@ rule token = parse
 | "," {COMMA} | "(" {OPEN} | ")" {CLOSE} | "skip" {SKIP} | "+" {PLUS}
 | "{" {BOPEN} | "}" {BCLOSE} | "minfty" {MINFTY} | "pinfty" {PINFTY}
 | ['a'-'z''A'-'Z''_']['a'-'z' 'A'-'Z' '0'-'9' '_']* {ID(Lexing.lexeme lexbuf)}
-| ['0'-'9']+ {NUM(Big_int.big_int_of_string(Lexing.lexeme lexbuf))}
+| ['0'-'9']+ {NUM(Big_int_Z.big_int_of_string(Lexing.lexeme lexbuf))}
 | _ {raise (Lex_error(Lexing.lexeme_start lexbuf))}
 | _ {raise Eof}
 

--- a/meta.yml
+++ b/meta.yml
@@ -53,9 +53,9 @@ supported_coq_versions:
 
 dependencies:
 - opam:
-    name: num
+    name: zarith
   description: |-
-    [num](https://opam.ocaml.org/packages/num/)
+    [num](https://opam.ocaml.org/packages/Zarith/)
 - opam:
     name: ocamlbuild
     version: '{build}'

--- a/parse_little.mly
+++ b/parse_little.mly
@@ -1,5 +1,5 @@
 %{
-  open Big_int
+  open Big_int_Z
   open String
   open Str_little
   open Str
@@ -25,7 +25,7 @@ let rec mk_precs l i =
 %}
 %token VARIABLES IN END WHILE DO DONE ASSIGN PLUS MINUS COMMA CONJ BANG
 %token SEMICOLON OPEN CLOSE BOPEN BCLOSE SKIP LT SOPEN SCLOSE MINFTY PINFTY
-%token <Big_int.big_int> NUM
+%token <Big_int_Z.big_int> NUM
 %token <string> ID
 %left PLUS
 %right CONJ


### PR DESCRIPTION
Add support for more recent versions of OCaml by replacing the use of `num` by `zarith`.