### PR TITLE
Port rocq 9 zarith

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ clean: Makefile.coq
 	+make -f Makefile.coq clean
 
 Makefile.coq:
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQBIN)rocq makefile -f _CoqProject -o Makefile.coq
 
 %: Makefile.coq
 	+make -f Makefile.coq $@

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -12,3 +12,4 @@ test_vcg.lil: ex_int.lil little.native
 clean::
 	rm -f Makefile.coq Makefile.coq.conf interp.ml*
 	rm -rf _build little.native proof_sqrt.v test_vcg.lil
+	rm -f parse_little.ml parse_little.mli

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,7 +1,7 @@
 post-all:: little.native proof_sqrt.v test_vcg.lil
 
 little.native: extract_interpret.vo parse_little.mly llex.mll str_little.ml little.ml
-	$(CAMLBIN)ocamlbuild -no-hygiene -classic-display -libs nums $@
+	$(CAMLBIN)ocamlbuild -use-ocamlfind -package zarith -no-hygiene -classic-display $@
 
 proof_sqrt.v: context_sqrt.v tail_sqrt.v sqrt.lil little.native
 	./little.native -vcg-coq < sqrt.lil | cat context_sqrt.v - tail_sqrt.v > proof_sqrt.v

--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 
 This is a survey of programming language semantics styles
 for a miniature example of a programming language, with their encoding
-in Coq, the proofs of equivalence of different styles, and the proof
+in Rocq (Coq), the proofs of equivalence of different styles, and the proof
 of soundess of tools obtained from axiomatic semantics or abstract
-interpretation.  The tools can be run inside Coq, thus making them
+interpretation.  The tools can be run inside Rocq, thus making them
 available for proof by reflection, and the code can also be extracted
 and connected to a yacc-based parser, thanks to the use of a functor
 parameterized by a module type of strings.  A hand-written parser is
-also provided in Coq, but there are no proofs associated.
+also provided in Rocq, but there are no proofs associated.
 
 The current version is only compatible with a recent version of Rocq
-(tested with version 9.0) but previous versions of this repository
-worked with older version of Coq
+(tested with versions 9.0 to 9.1) but previous versions of this repository
+worked with older version of Rocq and Coq
 
 
 ## Meta
@@ -46,10 +46,24 @@ worked with older version of Coq
 - Author(s):
   - Yves Bertot (initial)
 - Rocq-community maintainer(s):
-  - Kartik Singhal ([**@k4rtik**](https://github.com/k4rtik))
+  - Yves Bertot ([**@ybertot**](https://github.com/ybertot))
 - License: [MIT License](LICENSE)
 - Compatible Rocq/Coq versions: 9.0 or later
 - Additional dependencies:
+  - This is a survey of programming language semantics styles
+for a miniature example of a programming language, with their encoding
+in Rocq (Coq), the proofs of equivalence of different styles, and the proof
+of soundess of tools obtained from axiomatic semantics or abstract
+interpretation.  The tools can be run inside Rocq, thus making them
+available for proof by reflection, and the code can also be extracted
+and connected to a yacc-based parser, thanks to the use of a functor
+parameterized by a module type of strings.  A hand-written parser is
+also provided in Rocq, but there are no proofs associated.
+
+The current version is only compatible with a recent version of Rocq
+(tested with versions 9.0 to 9.1) but previous versions of this repository
+worked with older version of Rocq and Coq
+
   - [num](https://opam.ocaml.org/packages/num/)
   - [ocamlbuild](https://github.com/ocaml/ocamlbuild)
 - Rocq/Coq namespace: `Semantics`
@@ -62,25 +76,19 @@ The easiest way to install the latest released version of Semantics
 is via [OPAM](https://opam.ocaml.org/doc/Install.html):
 
 ```shell
-opam repo add coq-released https://coq.inria.fr/opam/released
+opam repo add rocq-released https://rocq-prover.org/opam/released
 opam install coq-semantics
 ```
 
-To instead build and install manually, you may encounter difficulties making
-sure that all dependencies for the compilation are present.  The dependencies
-are already declared in the `opam` package description, so it is better
-to rely on `opam` to compile dependencies with the following two lines:
+To instead build and install manually, you need to make sure that all the
+libraries this development depends on are installed.  This easiest to do that
+is still to rely on opam:
 
-```shell
-opam repo add coq-released https://coq.inria.fr/opam/released
-opam install --deps-only coq-semantics
-```
-
-You can then download the source and compile them as follows:
-
-```shell
+``` shell
 git clone https://github.com/coq-community/semantics.git
 cd semantics
+opam repo add rocq-released https://rocq-prover.org/opam/released
+opam install --deps-only .
 make   # or make -j <number-of-cores-on-your-machine> 
 make install
 ```
@@ -88,7 +96,7 @@ make install
 
 ## Description
 These files describe several approaches to the description of a simple
-programming language using the Coq system.
+programming language using the Rocq (formerly Coq) system.
 
 `syntax.v` the constructs of the language
 
@@ -124,14 +132,14 @@ programming language using the Coq system.
 
 `little_w_string.v`  The whole development is defined as a set of modules
   parameterized by a notion of strings.  This file instantiate the development
-  on the string package provided in Coq.
+  on the string package provided in Rocq.
 
 `parser.v` A parser for the language and assertions, which can be hooked on all
   the tools.  This is nice for the examples.  There are no proofs on this
   parser, and when parsing fails, it simply returns the "skip" program.
 
 `example.v`, `example2.v`, `ex_i.v`  These are examples where the abstract interpreter,
-  and the vcg are used in a reflective manner directly inside Coq.
+  and the vcg are used in a reflective manner directly inside Rocq.
 
 `extract_interpret.v`  This file contains the directives to extract code from
   the proved tools.
@@ -163,6 +171,6 @@ llex.mll the lexical analyser to be used with the parser.
   options:
   - `-interpreter` (just to execute a program)
   - `-vcg` (to generate the conditions for the verification of an annotated program)
-  - `-vcg-coq` (to generatedthe conditions in coq syntax)
+  - `-vcg-coq` (to generate the conditions in coq syntax)
   - `-static-analysis` (to run the abstract interpreter).
 

--- a/coq-semantics.opam
+++ b/coq-semantics.opam
@@ -30,8 +30,8 @@ worked with older version of Coq
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "9.0"}
-  "num" 
+  "rocq-stdlib" {>= "9.0"}
+  "zarith"
   "ocamlbuild" {build}
 ]
 

--- a/coq-semantics.opam
+++ b/coq-semantics.opam
@@ -2,7 +2,7 @@
 # Follow the instructions on https://github.com/coq-community/templates to regenerate.
 
 opam-version: "2.0"
-maintainer: "kartiksinghal@gmail.com"
+maintainer: "yves.bertot@inria.fr"
 version: "dev"
 
 homepage: "https://github.com/coq-community/semantics"
@@ -14,24 +14,25 @@ synopsis: "A survey of semantics styles, from natural semantics through structur
 description: """
 This is a survey of programming language semantics styles
 for a miniature example of a programming language, with their encoding
-in Coq, the proofs of equivalence of different styles, and the proof
+in Rocq (Coq), the proofs of equivalence of different styles, and the proof
 of soundess of tools obtained from axiomatic semantics or abstract
-interpretation.  The tools can be run inside Coq, thus making them
+interpretation.  The tools can be run inside Rocq, thus making them
 available for proof by reflection, and the code can also be extracted
 and connected to a yacc-based parser, thanks to the use of a functor
 parameterized by a module type of strings.  A hand-written parser is
-also provided in Coq, but there are no proofs associated.
+also provided in Rocq, but there are no proofs associated.
 
 The current version is only compatible with a recent version of Rocq
-(tested with version 9.0) but previous versions of this repository
-worked with older version of Coq
+(tested with versions 9.0 to 9.1) but previous versions of this repository
+worked with older version of Rocq and Coq
 """
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
+  "rocq-core" {>= "9.0"}
   "rocq-stdlib" {>= "9.0"}
-  "zarith"
+  "zarith" {>= "1.11"}
   "ocamlbuild" {build}
 ]
 

--- a/little.ml
+++ b/little.ml
@@ -1,4 +1,4 @@
-open Big_int
+module Big_int = Z
 open Parse_little
 open Interp
 open Str_little
@@ -7,7 +7,6 @@ open Str
 (* Recuperating the certified code from the file Interp. *)
 (* Str_little.Str is a module providing the string operations, based on
    ocaml native strings. *)
-
 module D = Interp.Coq_denot(Str_little.Str)
 module A = Interp.Coq_ax(Str_little.Str)
 module B = Interp.Coq_ab(Str_little.Str)
@@ -16,30 +15,31 @@ open A
 open D
 open L
 
-
 (* Displaying the results: first displaying integers. *)
 
+let two_big_int = Big_int.of_int 2
+
 let rec big_int_of_positive = function
-  Interp.XH -> unit_big_int
-| Interp.XI p -> succ_big_int (mult_int_big_int 2 (big_int_of_positive p))
-| Interp.XO p -> mult_int_big_int 2 (big_int_of_positive p)
+  Interp.XH -> Big_int.one
+| Interp.XI p -> Big_int.succ (Big_int.mul two_big_int (big_int_of_positive p))
+| Interp.XO p -> Big_int.mul two_big_int (big_int_of_positive p)
 
 let bigint_of_z = function
-  Interp.Z0 -> zero_big_int
+  Interp.Z0 -> Big_int.zero
 | Interp.Zpos x -> big_int_of_positive x
-| Interp.Zneg x -> minus_big_int (big_int_of_positive x)
+| Interp.Zneg x -> Big_int.neg (big_int_of_positive x)
   
 let rec display_result = function
   Interp.Nil -> ()
 | Interp.Cons(Interp.Pair(s, v), tl) ->
-  print_string (s ^ " " ^ string_of_big_int (bigint_of_z v) ^ "\n");
+  print_string (s ^ " " ^ Big_int.to_string (bigint_of_z v) ^ "\n");
   display_result tl
 
 (* Displaying assertions *)
 
 let rec string_of_expr = function
   Interp.Avar s -> s
-| Interp.Anum n -> string_of_big_int (bigint_of_z n)
+| Interp.Anum n -> Big_int.to_string (bigint_of_z n)
 | Interp.Aplus(e1, e2) -> string_of_expr e1 ^ "+" ^ string_of_expr e2
 
 let string_of_bexpr (Interp.Blt(e1, e2)) =
@@ -109,7 +109,7 @@ let rec collect_assert set = function
 
 let rec coq_expr = function
   Interp.Avar s -> s
-| Interp.Anum n -> string_of_big_int (bigint_of_z n)
+| Interp.Anum n -> Big_int.to_string (bigint_of_z n)
 | Interp.Aplus(e1,e2) -> coq_expr e1 ^ "+" ^ coq_expr e2
 
 let coq_bexpr (Interp.Blt(e1,e2)) = coq_expr e1 ^ " < " ^ coq_expr e2

--- a/llex.mll
+++ b/llex.mll
@@ -1,4 +1,5 @@
 {
+  module Big_int = Z
   open Parse_little;;
   exception Eof;;
   exception Lex_error of int;;
@@ -13,7 +14,7 @@ rule token = parse
 | "," {COMMA} | "(" {OPEN} | ")" {CLOSE} | "skip" {SKIP} | "+" {PLUS}
 | "{" {BOPEN} | "}" {BCLOSE} | "minfty" {MINFTY} | "pinfty" {PINFTY}
 | ['a'-'z''A'-'Z''_']['a'-'z' 'A'-'Z' '0'-'9' '_']* {ID(Lexing.lexeme lexbuf)}
-| ['0'-'9']+ {NUM(Big_int.big_int_of_string(Lexing.lexeme lexbuf))}
+| ['0'-'9']+ {NUM(Big_int.of_string(Lexing.lexeme lexbuf))}
 | _ {raise (Lex_error(Lexing.lexeme_start lexbuf))}
 | _ {raise Eof}
 

--- a/meta.yml
+++ b/meta.yml
@@ -1,6 +1,7 @@
 ---
 fullname: Semantics
 shortname: semantics
+opam_name: coq-semantics
 namespace: Semantics
 organization: coq-community
 community: true
@@ -14,17 +15,17 @@ synopsis: >-
 description: |
   This is a survey of programming language semantics styles
   for a miniature example of a programming language, with their encoding
-  in Coq, the proofs of equivalence of different styles, and the proof
+  in Rocq (Coq), the proofs of equivalence of different styles, and the proof
   of soundess of tools obtained from axiomatic semantics or abstract
-  interpretation.  The tools can be run inside Coq, thus making them
+  interpretation.  The tools can be run inside Rocq, thus making them
   available for proof by reflection, and the code can also be extracted
   and connected to a yacc-based parser, thanks to the use of a functor
   parameterized by a module type of strings.  A hand-written parser is
-  also provided in Coq, but there are no proofs associated.
+  also provided in Rocq, but there are no proofs associated.
 
   The current version is only compatible with a recent version of Rocq
-  (tested with version 9.0) but previous versions of this repository
-  worked with older version of Coq
+  (tested with versions 9.0 to 9.1) but previous versions of this repository
+  worked with older version of Rocq and Coq
 
 doi: 10.1017/CBO9780511770524.016
 
@@ -38,10 +39,10 @@ authors:
   initial: true
 
 maintainers:
-- name: Kartik Singhal
-  nickname: k4rtik
+- name: Yves Bertot
+  nickname: ybertot
 
-opam-file-maintainer: kartiksinghal@gmail.com
+opam-file-maintainer: yves.bertot@inria.fr
 
 license:
   fullname: MIT License
@@ -53,7 +54,9 @@ supported_coq_versions:
 
 dependencies:
 - opam:
-    name: num
+    name: rocq-stdlib
+- opam:
+    name: zarith
   description: |-
     [num](https://opam.ocaml.org/packages/num/)
 - opam:
@@ -81,7 +84,7 @@ categories:
 documentation: |
   ## Description
   These files describe several approaches to the description of a simple
-  programming language using the Coq system.
+  programming language using the Rocq (formerly Coq) system.
 
   `syntax.v` the constructs of the language
 
@@ -117,14 +120,14 @@ documentation: |
 
   `little_w_string.v`  The whole development is defined as a set of modules
     parameterized by a notion of strings.  This file instantiate the development
-    on the string package provided in Coq.
+    on the string package provided in Rocq.
 
   `parser.v` A parser for the language and assertions, which can be hooked on all
     the tools.  This is nice for the examples.  There are no proofs on this
     parser, and when parsing fails, it simply returns the "skip" program.
 
   `example.v`, `example2.v`, `ex_i.v`  These are examples where the abstract interpreter,
-    and the vcg are used in a reflective manner directly inside Coq.
+    and the vcg are used in a reflective manner directly inside Rocq.
 
   `extract_interpret.v`  This file contains the directives to extract code from
     the proved tools.
@@ -156,6 +159,6 @@ documentation: |
     options:
     - `-interpreter` (just to execute a program)
     - `-vcg` (to generate the conditions for the verification of an annotated program)
-    - `-vcg-coq` (to generatedthe conditions in coq syntax)
+    - `-vcg-coq` (to generate the conditions in coq syntax)
     - `-static-analysis` (to run the abstract interpreter).
 ---

--- a/parse_little.mly
+++ b/parse_little.mly
@@ -1,19 +1,23 @@
 %{
-  module Big_int = Z
+(* This code is actually taken into account after the token declarations.
+   so no module renaming is taken into account when declaring the tokens. *)
   open String
   open Str_little
   open Str
+(* Beware that module Interp should not be opened, to avoid that Inter.Z hides
+   the Z module from zarith. *)
+
 
 (* Making Coq data. *)
 
-let big_int2 = Big_int.of_int 2
+let big_int2 = Z.of_int 2
 
 let z_of_big_int n =
-    let rec f n = if Big_int.equal n Big_int.one then Interp.XH
-                else let q,r = Big_int.div_rem n big_int2 in
-                  if Big_int.equal r Big_int.one then Interp.XI(f q)
+    let rec f n = if Z.equal n Z.one then Interp.XH
+                else let q,r = Z.div_rem n big_int2 in
+                  if Z.equal r Z.one then Interp.XI(f q)
                   else Interp.XO(f q) in
-  if Big_int.equal n Big_int.zero then Interp.Z0 else Interp.Zpos(f n)
+  if Z.equal n Z.zero then Interp.Z0 else Interp.Zpos(f n)
 
 let p a b = Interp.Pair(a, b)
 let c a b = Interp.Cons(a, b)
@@ -25,7 +29,7 @@ let rec mk_precs l i =
 %}
 %token VARIABLES IN END WHILE DO DONE ASSIGN PLUS MINUS COMMA CONJ BANG
 %token SEMICOLON OPEN CLOSE BOPEN BCLOSE SKIP LT SOPEN SCLOSE MINFTY PINFTY
-%token <Big_int.t> NUM
+%token <Z.t> NUM
 %token <string> ID
 %left PLUS
 %right CONJ

--- a/parse_little.mly
+++ b/parse_little.mly
@@ -1,19 +1,19 @@
 %{
-  open Big_int
+  module Big_int = Z
   open String
   open Str_little
   open Str
 
 (* Making Coq data. *)
 
-let big_int2 = big_int_of_int 2
+let big_int2 = Big_int.of_int 2
 
 let z_of_big_int n =
-    let rec f n = if eq_big_int n unit_big_int then Interp.XH
-                else let q,r = quomod_big_int n big_int2 in
-                  if eq_big_int r unit_big_int then Interp.XI(f q)
+    let rec f n = if Big_int.equal n Big_int.one then Interp.XH
+                else let q,r = Big_int.div_rem n big_int2 in
+                  if Big_int.equal r Big_int.one then Interp.XI(f q)
                   else Interp.XO(f q) in
-  if eq_big_int n zero_big_int then Interp.Z0 else Interp.Zpos(f n)
+  if Big_int.equal n Big_int.zero then Interp.Z0 else Interp.Zpos(f n)
 
 let p a b = Interp.Pair(a, b)
 let c a b = Interp.Cons(a, b)
@@ -25,7 +25,7 @@ let rec mk_precs l i =
 %}
 %token VARIABLES IN END WHILE DO DONE ASSIGN PLUS MINUS COMMA CONJ BANG
 %token SEMICOLON OPEN CLOSE BOPEN BCLOSE SKIP LT SOPEN SCLOSE MINFTY PINFTY
-%token <Big_int.big_int> NUM
+%token <Big_int.t> NUM
 %token <string> ID
 %left PLUS
 %right CONJ


### PR DESCRIPTION
Use `rocq` commands at compilation time, use the `zarith` library.  Be careful about the need rename the `Z` module from
zarith to avoid a name clash with the `Z` module in the extracted code.